### PR TITLE
added support for relative IRIs

### DIFF
--- a/lib/ParserStream.js
+++ b/lib/ParserStream.js
@@ -38,6 +38,11 @@ class ParserStream extends Readable {
   term (plainTerm) {
     switch (plainTerm.termType) {
       case 'NamedNode':
+        if (plainTerm.value.startsWith('null:/')) {
+          // remove null:/ workaround for relative IRIs
+          return this.factory.namedNode(plainTerm.value.slice(6))
+        }
+
         return this.factory.namedNode(plainTerm.value)
       case 'BlankNode':
         return this.factory.blankNode(plainTerm.value.substr(2))
@@ -59,7 +64,8 @@ class ParserStream extends Readable {
         })
       }
 
-      const toRdfOptions = { base: this.baseIRI }
+      // use null:/ as workaround for relative IRIs
+      const toRdfOptions = { base: this.baseIRI || 'null:/' }
 
       // use context from options if given
       if (this.context) {

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,48 @@ describe('@rdfjs/parser-jsond', () => {
     })
   })
 
+  it('should support empty Named Node subjects', () => {
+    const example = {
+      '@id': '',
+      'http://example.org/predicate': 'object'
+    }
+
+    const parser = new JSONLDParser()
+    const stream = parser.import(stringToStream(JSON.stringify(example)))
+    const output = []
+
+    stream.on('data', (triple) => {
+      output.push(triple)
+    })
+
+    return waitFor(stream).then(() => {
+      assert.strictEqual(output.length, 1)
+      assert.strictEqual(output[0].subject.termType, 'NamedNode')
+      assert.strictEqual(output[0].subject.value, '')
+    })
+  })
+
+  it('should support relative Named Node subjects', () => {
+    const example = {
+      '@id': 'relative',
+      'http://example.org/predicate': 'object'
+    }
+
+    const parser = new JSONLDParser()
+    const stream = parser.import(stringToStream(JSON.stringify(example)))
+    const output = []
+
+    stream.on('data', (triple) => {
+      output.push(triple)
+    })
+
+    return waitFor(stream).then(() => {
+      assert.strictEqual(output.length, 1)
+      assert.strictEqual(output[0].subject.termType, 'NamedNode')
+      assert.strictEqual(output[0].subject.value, 'relative')
+    })
+  })
+
   it('should support Blank Node subjects', () => {
     const example = {
       'http://example.org/predicate': 'object'


### PR DESCRIPTION
Relative IRIs without `baseIRI` aren't supported by the `jsonld` package. As a workaround, `null:/` is used if no `baseIRI` is given and removed later when the `NamedNode` is created.