### PR TITLE
Bump jsonld to ^4.0.0 to remove dependency on vulnerable xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@rdfjs/data-model": "^1.0.1",
     "@rdfjs/sink": "^1.0.2",
     "concat-stream": "^2.0.0",
-    "jsonld": "^1.8.1",
+    "jsonld": "^4.0.0",
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Version up to jsonld 4.0.0 depended on xmldom [^1]. New versions of xmldom are published under @xmldom/xmldom [^2]. The version that old jsonld depends on has security advisories against it.

By bumping the jsonld dependency the advisories are dealt with.

All tests pass locally (`npm test`).

Please let me know if there is anything else I can do to get this merged. Cheers.

[^1]: [jsonld changelog for 4.0.0](https://github.com/digitalbazaar/jsonld.js/blob/ee976d20ef55ae3bf782e8dae46b9b1862470b26/CHANGELOG.md#400---2021-02-11)
[^2]: [Announcement and reasons use of @xmldom/xmldom](https://github.com/xmldom/xmldom/issues/271)